### PR TITLE
Reject the promise when a callback throws an error

### DIFF
--- a/CancelablePromise.js
+++ b/CancelablePromise.js
@@ -1,3 +1,11 @@
+const handleCallback = (resolve, reject, callback, r) => {
+  try {
+    resolve(callback(r));
+  } catch (e) {
+    reject(e);
+  }
+};
+
 export default class CancelablePromise {
   static all(iterable) {
     return new CancelablePromise((y, n) => {
@@ -30,20 +38,12 @@ export default class CancelablePromise {
 
   then(success, error) {
     const p = new CancelablePromise((resolve, reject) => {
-      const handleCallback = (callback, r) => {
-        try {
-          resolve(callback(r));
-        } catch (e) {
-          reject(e);
-        }
-      };
-
       this._promise.then((r) => {
         if (this._canceled) {
           p.cancel();
         }
         if (success && !this._canceled) {
-          handleCallback(success, r);
+          handleCallback(resolve, reject, success, r);
         } else {
           resolve(r);
         }
@@ -52,7 +52,7 @@ export default class CancelablePromise {
           p.cancel();
         }
         if (error && !this._canceled) {
-          handleCallback(error, r);
+          handleCallback(resolve, reject, error, r);
         } else {
           reject(r);
         }

--- a/CancelablePromise.js
+++ b/CancelablePromise.js
@@ -30,12 +30,20 @@ export default class CancelablePromise {
 
   then(success, error) {
     const p = new CancelablePromise((resolve, reject) => {
+      const handleCallback = (callback, r) => {
+        try {
+          resolve(callback(r));
+        } catch (e) {
+          reject(e);
+        }
+      };
+
       this._promise.then((r) => {
         if (this._canceled) {
           p.cancel();
         }
         if (success && !this._canceled) {
-          resolve(success(r));
+          handleCallback(success, r);
         } else {
           resolve(r);
         }
@@ -44,7 +52,7 @@ export default class CancelablePromise {
           p.cancel();
         }
         if (error && !this._canceled) {
-          resolve(error(r));
+          handleCallback(error, r);
         } else {
           reject(r);
         }

--- a/CancelablePromise.spec.js
+++ b/CancelablePromise.spec.js
@@ -221,4 +221,40 @@ describe(__filename, () => {
     };
     setTimeout(end, 0);
   });
+
+  it('should reject the promise when the success callback throws an error', (done) => {
+    const promise = new CancelablePromise((resolve, reject) => {
+      resolve('test123');
+    });
+    let hasFailed = true;
+
+    promise.then((value) => {
+      throw new Error('The callback threw an error');
+    }).catch((error) => {
+      hasFailed = false;
+    });
+
+    const end = () => {
+      done(hasFailed ? new Error('Promise should be rejected when the success callback throws an error') : undefined);
+    };
+    setTimeout(end, 0);
+  });
+
+  it('should reject the promise when the error callback throws an error', (done) => {
+    const promise = new CancelablePromise((resolve, reject) => {
+      reject(new Error('test123'));
+    });
+    let hasFailed = true;
+
+    promise.catch((error) => {
+      throw new Error('The callback threw an error');
+    }).catch((error) => {
+      hasFailed = false;
+    });
+
+    const end = () => {
+      done(hasFailed ? new Error('Promise should be rejected when the error callback throws an error') : undefined);
+    };
+    setTimeout(end, 0);
+  });
 });


### PR DESCRIPTION
Hi,
I  came across a difference in behaviour between CancelablePromise and native ES6 promises: when the success or error callbacks throw an error, the returned promise should be rejected. Currently, the promise stays pending indefinitely.
This PR fixes that and adds the corresponding tests.