### PR TITLE
Add error callback arg to cancel

### DIFF
--- a/CancelablePromise.js
+++ b/CancelablePromise.js
@@ -65,8 +65,11 @@ export default class CancelablePromise {
     return this.then(undefined, error);
   }
 
-  cancel() {
+  cancel(error) {
     this._canceled = true;
+    if (error) {
+      this._promise.catch(error);
+    }
     return this;
   }
 }

--- a/CancelablePromise.js
+++ b/CancelablePromise.js
@@ -65,10 +65,10 @@ export default class CancelablePromise {
     return this.then(undefined, error);
   }
 
-  cancel(error) {
+  cancel(errorCallback) {
     this._canceled = true;
     if (error) {
-      this._promise.catch(error);
+      this._promise.catch(errorCallback);
     }
     return this;
   }

--- a/CancelablePromise.spec.js
+++ b/CancelablePromise.spec.js
@@ -257,4 +257,31 @@ describe(__filename, () => {
     };
     setTimeout(end, 0);
   });
+
+  it('should call cancel function if rejected after a cancel', (done) => {
+    const promise = new CancelablePromise((resolve, reject) => {
+      reject(new Error('test456'));
+    });
+    let cancelCalled = false;
+    let catchCalled = false;
+
+    promise.cancel((err) => {
+      cancelCalled = true;
+    });
+
+    promise.catch((err) => {
+      catchCalled = true;
+    })
+
+    const end = () => {
+      let hasFailed = false;
+      if (catchCalled) {
+        hasFailed = 'Promise should NOT call catch when rejected after a cancel';
+      } else if (!cancelCalled) {
+        hasFailed = 'Promise should call cancel error callback on a rejection';
+      }
+      done(!!hasFailed ? new Error(hasFailed) : undefined);
+    };
+    setTimeout(end, 0);
+  })
 });


### PR DESCRIPTION
The following code works as expected as far as `.cancel()` not triggering the reject callback from `then()`. 

```
const pr = new CancelablePromise((resolve, reject) => {
  reject(new Error("test"));
});

pr.cancel();

pr.then(
  () => {
    console.log("RESOLVE");
  },
  () => {
    console.log("REJECT");
  }
);
```

However I then get "Uncaught (in promise) Error". I'm proposing the ability to pass an error callback to cancel in order to gracefully handle these.

```
const pr = new CancelablePromise((resolve, reject) => {
  reject(new Error("test"));
});

pr.cancel((err) => {
  // I can do something with the error here, if I wish, or just pass a noop to silence it
  console.log("THIS WILL FIRE");
});

pr.then(
  () => {
    console.log("RESOLVE");
  },
  () => {
    console.log("REJECT");
  }
);
```