### PR TITLE
Universal import support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,20 @@
     "cancelable",
     "cancellable"
   ],
-  "main": "umd/CancelablePromise.js",
-  "browser": "umd/CancelablePromise.js",
-  "module": "esm/CancelablePromise.mjs",
-  "types": "esm/CancelablePromise.d.ts",
+  "type": "commonjs",
+  "exports": {
+    "module": "./esm/CancelablePromise.mjs",
+    "import": {
+      "types": "./esm/CancelablePromise.d.mts",
+      "default": "./esm/CancelablePromise.mjs"
+    },
+    "require": {
+      "types": "./umd/CancelablePromise.d.ts",
+      "default": "./umd/CancelablePromise.js"
+    },
+    "default": "./umd/CancelablePromise.js"
+  },
+  "types": "./umd/CancelablePromise.d.ts",
   "files": [
     "umd/CancelablePromise.js",
     "umd/CancelablePromise.js.map",
@@ -21,7 +31,7 @@
     "esm/CancelablePromise.mjs.map",
     "esm/CancelablePromise.min.mjs",
     "esm/CancelablePromise.min.mjs.map",
-    "esm/CancelablePromise.d.ts",
+    "esm/CancelablePromise.d.mts",
     "src/CancelablePromise.ts",
     "LICENSE",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -8,19 +8,29 @@
     "cancellable"
   ],
   "type": "commonjs",
+  "main": "umd/CancelablePromise.js",
+  "browser": "umd/CancelablePromise.js",
+  "module": "esm/CancelablePromise.mjs",
+  "types": "umd/CancelablePromise.d.ts",
   "exports": {
-    "module": "./esm/CancelablePromise.mjs",
-    "import": {
-      "types": "./esm/CancelablePromise.d.mts",
-      "default": "./esm/CancelablePromise.mjs"
-    },
-    "require": {
-      "types": "./umd/CancelablePromise.d.ts",
+    ".": {
+      "module": "./esm/CancelablePromise.mjs",
+      "import": {
+        "types": "./esm/CancelablePromise.d.mts",
+        "default": "./esm/CancelablePromise.mjs"
+      },
+      "browser": {
+        "types": "./esm/CancelablePromise.d.mts",
+        "default": "./esm/CancelablePromise.mjs"
+      },
+      "require": {
+        "types": "./umd/CancelablePromise.d.ts",
+        "default": "./umd/CancelablePromise.js"
+      },
       "default": "./umd/CancelablePromise.js"
     },
-    "default": "./umd/CancelablePromise.js"
+    "./package.json": "./package.json"
   },
-  "types": "./umd/CancelablePromise.d.ts",
   "files": [
     "umd/CancelablePromise.js",
     "umd/CancelablePromise.js.map",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "commonjs",
   "main": "umd/CancelablePromise.js",
-  "browser": "umd/CancelablePromise.js",
+  "browser": "esm/CancelablePromise.mjs",
   "module": "esm/CancelablePromise.mjs",
   "types": "umd/CancelablePromise.d.ts",
   "exports": {
@@ -31,6 +31,8 @@
     },
     "./package.json": "./package.json"
   },
+  "unpkg": "./umd/CancelablePromise.js",
+  "jsdelivr": "./umd/CancelablePromise.js",
   "files": [
     "umd/CancelablePromise.js",
     "umd/CancelablePromise.js.map",

--- a/scripts.js
+++ b/scripts.js
@@ -31,7 +31,7 @@ async function clean() {
 }
 
 async function copy() {
-  await fs.copy('umd/CancelablePromise.d.ts', 'esm/CancelablePromise.d.ts');
+  await fs.copy('umd/CancelablePromise.d.ts', 'esm/CancelablePromise.d.mts');
 }
 
 async function logVersionToPublish() {


### PR DESCRIPTION
This should hopefully address the hell that is universal compatibility across all JS ecosystems, versions, and bundlers.
Resolves #940

Here's a bunch of resources that I utilized to come to this solution:

- https://publint.dev/cancelable-promise@4.3.1
- https://publint.dev/rules#has_module_but_no_exports
- https://github.com/frehner/modern-guide-to-packaging-js-library?tab=readme-ov-file#define-your-exports
- https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md
  - This issue came up from ATTW, and required me to switch the ESM types to `.d.mts`

To verify the exports are okay, I ran
```sh
npm run build
npx attw
npx publint
```

All turned up with no problems.

I tested with ESM Node and Typescript, but CJS Node and browser imports should be tested to ensure no breaking changes.