### PR TITLE
chore(sxmc-283): Add lucy to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @alkemics/sxm-core
+package.json @alkemics/sxm-core @lucyalkemics
+package-lock.json @alkemics/sxm-core @lucyalkemics


### PR DESCRIPTION
## Problem

[Jira ticket](https://salsify.atlassian.net/browse/SXMC-283)

In order for dependabot auto merge to function properly Lucy must have permission to approve some files.

## Solution

Add Lucy as code owner to relevant files.

Prime: @alkemics/sxm-core
