### PR TITLE
chore(SXMC-1623): Update CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ci: alkemics/ci@2
+  ci: alkemics/ci@3
 
 aliases:
   - filter-tags-only: &tags-only


### PR DESCRIPTION
## Problem

[Jira ticket](https://salsify.atlassian.net/browse/SXMC-1623)

Update CircleCI orb from alkemics/ci@2 to alkemics/ci@3.

## Solution

Updated orb reference in CircleCI configuration files.

## Caveats/Notes

None

Prime:

cc @ alkemics/sxm-core