### PR TITLE
chore(SXMC-1780): update ci orb to version 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ci: alkemics/ci@3
+  ci: alkemics/ci@4
 
 aliases:
   - filter-tags-only: &tags-only


### PR DESCRIPTION
## Problem
[SXMC-1780](https://salsify.atlassian.net/browse/SXMC-1780)

CCI alkemics/ci orb is out of date.

## Solution
Bump `alkemics/ci@4` in all `.circleci/*.yml` files.

## Caveats/Notes
This PR was generated automatically by update-orb.sh

cc @alkemics/sxm-core

[SXMC-1780]: https://salsify.atlassian.net/browse/SXMC-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ