### PR TITLE
chore(SXMC-1813): upgrade alkemics/ci orb from v4 to v5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ci: alkemics/ci@4
+  ci: alkemics/ci@5
 
 aliases:
   - filter-tags-only: &tags-only


### PR DESCRIPTION
Upgrade CircleCI orb from `alkemics/ci@4` to `alkemics/ci@5` via copier update.