### PR TITLE
chore(SXMC-1883): apply copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,23 @@
+# Changes here will be overwritten by Copier; do not edit manually.
+_commit: v1.11.2
+_src_path: gh:alkemics/copier-templates
+auto_merge_matchers:
+  - dependency-type: all
+    update-type: minor
+dependabot_extra_ignores: []
+dependabot_group_exclude_patterns: []
+dependabot_max_prs: 5
+project_language: javascript
+project_name: CancelablePromise
+test_runner: none
+with_build_check: false
+with_couchbase: false
+with_elasticsearch: false
+with_eslint: true
+with_mysql: false
+with_publish: true
+with_semver_release: true
+with_storybook: false
+with_stylelint: false
+with_typescript: true
+with_webpack_types: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    open-pull-requests-limit: 5
     groups:
       internal-deps-minor-and-patch:
         applies-to: version-updates

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,17 @@
+name: dependabot-merge
+on: pull_request
+
+jobs:
+  dependabot-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: alkemics/lib-action-dependabot-merge
+          ref: v2
+          path: .lib-action-dependabot-merge
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
+      - uses: ./.lib-action-dependabot-merge
+        with:
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}


### PR DESCRIPTION
## Problem
[SXMC-1883](https://salsify.atlassian.net/browse/SXMC-1883)

Managing dependabot configurations manually across 130 repos is inefficient

## Solution
Apply copier dependabot templates

## Caveats/Notes
May include other migrations and template updates

cc: @alkemics/sxm-core

[SXMC-1883]: https://salsify.atlassian.net/browse/SXMC-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ