### PR TITLE
chore(SXMC-1410): [copier-templates] add dependabot cooldown

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; do not edit manually.
-_commit: v1.12.6
+_commit: v1.14.0
 _src_path: gh:alkemics/copier-templates
 auto_merge_matchers:
 -   dependency-type: all

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 21
+      exclude:
+        - "@alkem/*"
     groups:
       internal-deps-minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
## Problem
[SXMC-1410](https://salsify.atlassian.net/browse/SXMC-1410)

Not using a cooldown period makes us more open to supply chain attacks.

## Solution
Add a cooldown period (21 days).

## Caveats/Notes
This PR was generated by copier templates.

[SXMC-1410]: https://salsify.atlassian.net/browse/SXMC-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ