### PR TITLE
chore(SXMC-2076): [copier-templates] add npmrc with private registries to front repositories

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; do not edit manually.
-_commit: v1.14.0
+_commit: v1.15.0
 _src_path: gh:alkemics/copier-templates
 auto_merge_matchers:
 -   dependency-type: all

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@alkem:registry=https://npm.salsify.com/api/npm/npm-local/
+@salsify:registry=https://npm.salsify.com/api/npm/npm-local/


### PR DESCRIPTION
## Problem
[SXMC-2076](https://salsify.atlassian.net/browse/SXMC-2076)

Dependabot no longer attempts to infer .npmrc configuration for npm private registries, and due to this change, our front repositories aren’t able to open new Dependabot PRs, as Dependabot no longer can resolve @alkem/* and @salsify/* scopes.

## Solution
This adds the .npmrc config file with the private Salsify scopes.

## Caveats/Notes
This PR was generated by copier-templates. This PR was generated by copier templates.

Prime: @guilhermewm
cc: @alkemics/sxm-core

[SXMC-2076]: https://salsify.atlassian.net/browse/SXMC-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ